### PR TITLE
Use pypi dist for udata-hydra and udata-analysis-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 .env.hydra
 .env.analysis
-csv-detective/
-udata-analysis-service/
-udata-datalake-service/
 minio-data/
 export-resource.csv

--- a/Dockerfile.analysis.consumer
+++ b/Dockerfile.analysis.consumer
@@ -2,16 +2,7 @@ FROM python:3.9
 
 WORKDIR /app
 
-COPY ./udata-analysis-service/requirements.txt .
-
-RUN pip install -r requirements.txt
-RUN pip install csv-detective==0.4.3
-
-RUN pip install flit
-
-COPY ./udata-analysis-service/ .
-
-RUN FLIT_ROOT_INSTALL=1 make install
+RUN pip install udata-analysis-service
 
 ENTRYPOINT ["udata-analysis-service", "consume"]
 

--- a/Dockerfile.analysis.worker
+++ b/Dockerfile.analysis.worker
@@ -2,16 +2,7 @@ FROM python:3.9
 
 WORKDIR /app
 
-COPY ./udata-analysis-service/requirements.txt .
-
-RUN pip install -r requirements.txt
-RUN pip install csv-detective==0.4.3
-
-RUN pip install flit
-
-COPY ./udata-analysis-service/ .
-
-RUN FLIT_ROOT_INSTALL=1 make install
+RUN pip install udata-analysis-service
 
 ENTRYPOINT ["udata-analysis-service", "work"]
 

--- a/Dockerfile.hydra.consumer
+++ b/Dockerfile.hydra.consumer
@@ -2,9 +2,7 @@ FROM python:3.9
 
 WORKDIR /app
 
-COPY ./udata-datalake-service/ .
-RUN make deps
-RUN pip install .
+RUN pip install udata-hydra
 
-ENTRYPOINT ["hydra", "run-kafka-integration"]
+ENTRYPOINT ["udata-hydra", "run-kafka-integration"]
 

--- a/Dockerfile.hydra.crawler
+++ b/Dockerfile.hydra.crawler
@@ -2,13 +2,10 @@ FROM python:3.9
 
 WORKDIR /app
 
-COPY ./udata-datalake-service/ .
+RUN pip install udata-hydra
+
 COPY ./hydra.sh .
 RUN chmod +x ./hydra.sh
-RUN make deps
-RUN pip install .
-#RUN hydra init-db
-# RUN hydra load-catalog
 
 ENTRYPOINT ["/app/hydra.sh"]
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ```
 cp .env.analysis.example .env.analysis # Make changes if you want
-cp .env.hydra.example .env.datalake # Make changes if you want
-./init.sh # Beware, download of catalog is desactivated by default, you have to uncomment it for the first time
+cp .env.hydra.example .env.hydra # Make changes if you want
+./init.sh # Beware, download of catalog should be done only the first time
 docker-compose up --build -d
 ```
 

--- a/hydra.sh
+++ b/hydra.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-hydra init-db
-#hydra load-catalog
-hydra-crawl
+udata-hydra init-db
+#udata-hydra load-catalog
+udata-hydra-crawl

--- a/init.sh
+++ b/init.sh
@@ -1,3 +1,1 @@
-git clone git@github.com:opendatateam/udata-datalake-service.git
-git clone git@github.com:etalab/udata-analysis-service.git
-#wget https://www.data.gouv.fr/fr/datasets/r/4babf5f2-6a9c-45b5-9144-ca5eae6a7a6d && mv 4babf5f2-6a9c-45b5-9144-ca5eae6a7a6d export-resource.csv
+wget https://www.data.gouv.fr/fr/datasets/r/4babf5f2-6a9c-45b5-9144-ca5eae6a7a6d && mv 4babf5f2-6a9c-45b5-9144-ca5eae6a7a6d export-resource.csv


### PR DESCRIPTION
Use pypi dist for udata-hydra and udata-analysis-service instead of a git clone.

I had trouble running `init-db` on startup, maybe because it is called before postgres is ready?