### PR TITLE
Kafka + zookeeper -> redpanda

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,27 @@ cp config/.env.hydra.example config/.env.hydra # Make changes if you want
 cp config/.env.csvapi.example config/.env.csvapi # Make changes if you want
 ./get_source.sh # To execute services with source instead of pypi. NB : csvapi with kafka integration has no pypi package yet, you have to download source anyway.
 docker-compose -f docker-compose-shared.yml -f docker-compose-with-source.yml up --build -d  # if you want to execute with source
+docker-compose -f docker-compose-shared.yml -f docker-compose-with-source.yml -f docker-compose-console.yml up --build -d  # if you want to execute with source and launch redpanda's console
 docker-compose -f docker-compose-shared.yml -f docker-compose-with-pypi.yml up --build -d # if you want to execute with pypi packages
 ```
 
 # Services
 
-- kafka with zookeeper
+- redpanda (kafka replacement)
 - minio
-- hydra service :
+- hydra service
   - redis
   - postgres
   - consumer kafka
   - crawler
-- analysis service :
+- analysis service
   - redis
   - consumer kafka
   - worker
 - csvapi service
   - server # localhost:8000
   - consumer
+- [redpanda console](https://github.com/redpanda-data/console) # localhost:8080
 
 # Tooling
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # How to
 
 ```
-cp analysis/.env.analysis.example analysis/.env.analysis # Make changes if you want
-cp hydra/.env.hydra.example hydra/.env.hydra # Make changes if you want
-cp csvapi/.env.csvapi.example csvapi/.env.csvapi # Make changes if you want
+cp config/.env.analysis.example config/.env.analysis # Make changes if you want
+cp config/.env.hydra.example config/.env.hydra # Make changes if you want
+cp config/.env.csvapi.example config/.env.csvapi # Make changes if you want
 ./get_source.sh # To execute services with source instead of pypi. NB : csvapi with kafka integration has no pypi package yet, you have to download source anyway.
-docker-compose -f docker-compose-with-source.yml up --build -d  # if you want to execute with source
-docker-compose -f docker-compose-with-pypi.yml up --build -d # if you want to execute with pypi packages
+docker-compose -f docker-compose-shared.yml -f docker-compose-with-source.yml up --build -d  # if you want to execute with source
+docker-compose -f docker-compose-shared.yml -f docker-compose-with-pypi.yml up --build -d # if you want to execute with pypi packages
 ```
 
 # Services

--- a/docker-compose-console.yml
+++ b/docker-compose-console.yml
@@ -1,0 +1,21 @@
+# depends on docker-compose-shared.yml
+
+version: "3.8"
+services:
+  console:
+    image: docker.redpanda.com/vectorized/console
+    restart: on-failure
+    entrypoint: /bin/sh
+    command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
+    environment:
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["broker:29092"]
+          schemaRegistry:
+            enabled: true
+            urls: ["http://broker:8081"]
+    ports:
+      - "8080:8080"
+    depends_on:
+      - broker

--- a/docker-compose-shared.yml
+++ b/docker-compose-shared.yml
@@ -1,0 +1,59 @@
+# Share components (middlewares)
+version: "3.8"
+
+services:
+  broker:
+    # NB: do not use v22 since redpanda.auto_create_topics_enabled is not supported
+    # cf https://cwiki.apache.org/confluence/display/KAFKA/KIP-487%3A+Client-side+Automatic+Topic+Creation+on+Producer
+    # also for more thoughts about this option even in Kafka
+    image: docker.vectorized.io/vectorized/redpanda:v21.11.19
+    container_name: broker
+    command:
+      - redpanda start
+      - --smp 1
+      - --reserve 0M
+      - --overprovisioned
+      - --node-id 0
+      - --set redpanda.auto_create_topics_enabled=true
+      - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+    ports:
+      - 9092:9092
+      - 29092:29092
+
+  minio:
+    hostname: minio
+    image: 'minio/minio:RELEASE.2021-01-08T21-18-21Z'
+    container_name: minio
+    ports:
+      - '9000:9000'
+    volumes:
+      - ./minio-data:/data
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: password
+    command: server /data
+
+  hydra-postgres:
+    build:
+      context: .
+      dockerfile: dockerfiles/hydra/Dockerfile.hydra.postgres
+    container_name: hydra-postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  hydra-redis:
+    image: redis:latest
+    container_name: hydra-redis
+    command: ["redis-server", "--bind", "0.0.0.0", "--port", "6380"]
+
+  analysis-redis:
+    image: redis:latest
+    container_name: analysis-redis
+    command: ["redis-server", "--bind", "0.0.0.0", "--port", "6380"]

--- a/docker-compose-shared.yml
+++ b/docker-compose-shared.yml
@@ -17,7 +17,11 @@ services:
       - --set redpanda.auto_create_topics_enabled=true
       - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
       - --advertise-kafka-addr PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr 0.0.0.0:8082
+      - --advertise-pandaproxy-addr localhost:8082
     ports:
+      - 8081:8081
+      - 8082:8082
       - 9092:9092
       - 29092:29092
 

--- a/docker-compose-with-pypi.yml
+++ b/docker-compose-with-pypi.yml
@@ -1,71 +1,7 @@
+# depends on docker-compose-shared.yml
+
 version: "3.8"
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-server:7.0.0
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
-    ports:
-      - "9092:9092"
-      - "9101:9101"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
-      KAFKA_ADVERTISED_HOST_NAME: 'broker'
-
-  minio:
-    hostname: minio
-    image: 'minio/minio:RELEASE.2021-01-08T21-18-21Z'
-    container_name: minio
-    ports:
-      - '9000:9000'
-    volumes:
-      - ./minio-data:/data
-    environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: password
-    command: server /data
-
-  hydra-postgres:
-    build:
-      context: .
-      dockerfile: dockerfiles/hydra/Dockerfile.hydra.postgres
-    container_name: hydra-postgres
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: postgres
-    healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   hydra-consumer:
     build:
       context: .
@@ -90,11 +26,6 @@ services:
     container_name: hydra-crawler
     entrypoint: udata-hydra-crawl
 
-  hydra-redis:
-    image: redis:latest
-    container_name: hydra-redis
-    command: ["redis-server", "--bind", "0.0.0.0", "--port", "6380"]
-
   analysis-consumer:
     build:
       context: .
@@ -112,11 +43,6 @@ services:
       - ./config/.env.analysis
     container_name: analysis-worker
     entrypoint: udata-analysis-service work
-
-  analysis-redis:
-    image: redis:latest
-    container_name: analysis-redis
-    command: ["redis-server", "--bind", "0.0.0.0", "--port", "6380"]
 
   csvapi-server:
     build:

--- a/docker-compose-with-source.yml
+++ b/docker-compose-with-source.yml
@@ -1,71 +1,7 @@
+# depends on docker-compose-shared.yml
+
 version: "3.8"
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-server:7.0.0
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
-    ports:
-      - "9092:9092"
-      - "9101:9101"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
-      KAFKA_ADVERTISED_HOST_NAME: 'broker'
-
-  minio:
-    hostname: minio
-    image: 'minio/minio:RELEASE.2021-01-08T21-18-21Z'
-    container_name: minio
-    ports:
-      - '9000:9000'
-    volumes:
-      - ./minio-data:/data
-    environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: password
-    command: server /data
-
-  hydra-postgres:
-    build:
-      context: .
-      dockerfile: dockerfiles/hydra/Dockerfile.hydra.postgres
-    container_name: hydra-postgres
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: postgres
-    healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   hydra-consumer:
     build:
       context: .
@@ -90,11 +26,6 @@ services:
     container_name: hydra-crawler
     entrypoint: udata-hydra-crawl
 
-  hydra-redis:
-    image: redis:latest
-    container_name: hydra-redis
-    command: ["redis-server", "--bind", "0.0.0.0", "--port", "6380"]
-
   analysis-consumer:
     build:
       context: .
@@ -112,11 +43,6 @@ services:
       - ./config/.env.analysis
     container_name: analysis-worker
     entrypoint: udata-analysis-service work
-
-  analysis-redis:
-    image: redis:latest
-    container_name: analysis-redis
-    command: ["redis-server", "--bind", "0.0.0.0", "--port", "6380"]
 
   csvapi-server:
     build:

--- a/dockerfiles/csvapi/Dockerfile.csvapi.with.pypi
+++ b/dockerfiles/csvapi/Dockerfile.csvapi.with.pypi
@@ -1,4 +1,0 @@
-FROM python:3.9
-
-WORKDIR /app
-RUN pip install udata-hydra

--- a/get_source.sh
+++ b/get_source.sh
@@ -1,5 +1,1 @@
-cd hydra && git clone git@github.com:opendatateam/udata-hydra.git
-cd ..
-cd analysis && git clone git@github.com:etalab/udata-analysis-service.git
-cd ..
-cd csvapi && git clone git@github.com:etalab/csvapi.git -b kafka-integration
+git submodule update --init --recursive


### PR DESCRIPTION
This uses redpanda instead of Kafka + zookeeper.

Advantages:
- only one service
- much much smaller image
- starts up much quicker
- less verbose logging, but still enough
- behaviour seems more consistent between runs compared to Kafka (for example #6 pops up every time with this setup, instead of ~randomly with Kafka)

This also refactors the compose files to avoid repetition, there's a now a shared `docker-compose-shared.yml` with services common between `with-source` and  `with-pypi`.

And one more thing: optional (dedicated compose file) [redpanda console](https://github.com/redpanda-data/console) which seems very nice. For example, I think I got the gist of #6 just by running the tests and inspecting the messages. I don't know how this compares to the Kafka's alternative.

<img width="1153" alt="Capture d’écran 2022-08-11 à 14 47 22" src="https://user-images.githubusercontent.com/119625/184138344-652ba371-d31f-477c-a1e1-026d049c4309.png">

Iterates on https://github.com/etalab/data.gouv.fr/issues/908