### PR TITLE
Use poetry to install with source

### DIFF
--- a/docker-compose-with-source.yml
+++ b/docker-compose-with-source.yml
@@ -12,7 +12,7 @@ services:
       hydra-postgres:
         condition: service_healthy
     container_name: hydra-consumer
-    entrypoint: udata-hydra run-kafka-integration
+    entrypoint: poetry run udata-hydra run-kafka-integration
 
   hydra-crawler:
     build:
@@ -24,7 +24,7 @@ services:
       hydra-postgres:
         condition: service_healthy
     container_name: hydra-crawler
-    entrypoint: udata-hydra-crawl
+    entrypoint: poetry run udata-hydra-crawl
 
   analysis-consumer:
     build:
@@ -33,7 +33,7 @@ services:
     env_file:
       - ./config/.env.analysis
     container_name: analysis-consumer
-    entrypoint: udata-analysis-service consume
+    entrypoint: poetry run udata-analysis-service consume
 
   analysis-worker:
     build:
@@ -42,7 +42,7 @@ services:
     env_file:
       - ./config/.env.analysis
     container_name: analysis-worker
-    entrypoint: udata-analysis-service work
+    entrypoint: poetry run udata-analysis-service work
 
   csvapi-server:
     build:
@@ -55,7 +55,7 @@ services:
     container_name: csvapi-server
     volumes:
       - ./csvapi/dbs:/app/dbs
-    entrypoint: csvapi serve -h 0.0.0.0 -p 8000
+    entrypoint: poetry run csvapi serve -h 0.0.0.0 -p 8000
 
   csvapi-consumer:
     build:
@@ -66,4 +66,4 @@ services:
     container_name: csvapi-consumer
     volumes:
       - ./csvapi/dbs:/app/dbs
-    entrypoint: csvapi consume
+    entrypoint: poetry run csvapi consume

--- a/dockerfiles/analysis/Dockerfile.analysis.with.source
+++ b/dockerfiles/analysis/Dockerfile.analysis.with.source
@@ -2,11 +2,11 @@ FROM python:3.9
 
 WORKDIR /app
 
-RUN pip install flit
+RUN pip install --upgrade pip
+RUN pip install poetry
 
 COPY ./udata-analysis-service/ .
 
-RUN FLIT_ROOT_INSTALL=1 make install
+RUN poetry install
 
 #ENTRYPOINT ["udata-analysis-service", "consume"]
-

--- a/dockerfiles/csvapi/Dockerfile.csvapi.with.source
+++ b/dockerfiles/csvapi/Dockerfile.csvapi.with.source
@@ -2,8 +2,9 @@ FROM python:3.9
 
 WORKDIR /app
 
+RUN pip install --upgrade pip
+RUN pip install poetry
+
 COPY ./csvapi/ .
 
-RUN pip install -e .
-RUN pip install Jinja2==3.0.3
-RUN pip install Werkzeug==1.0.0
+RUN poetry install

--- a/dockerfiles/hydra/Dockerfile.hydra.with.source
+++ b/dockerfiles/hydra/Dockerfile.hydra.with.source
@@ -2,6 +2,9 @@ FROM python:3.9
 
 WORKDIR /app
 
+RUN pip install --upgrade pip
+RUN pip install poetry
+
 COPY ./udata-hydra/ .
-RUN make deps
-RUN pip install .
+
+RUN poetry install

--- a/udata_event_orchestration/cli.py
+++ b/udata_event_orchestration/cli.py
@@ -23,8 +23,7 @@ def cli():
 @cli.command()
 def consume():
     logging.basicConfig(level=logging.INFO)
-    print('coucou')
-    consumer = KafkaConsumer(bootstrap_servers=f"{KAFKA_HOST}:{KAFKA_PORT}", group_id='toto')
+    consumer = KafkaConsumer(bootstrap_servers=f"{KAFKA_HOST}:{KAFKA_PORT}", group_id='uket_debug_consumer')
     consumer.subscribe([PREFIX_TOPIC+'.'+x['topic'] for x in messages])
     for message in consumer:
         try:


### PR DESCRIPTION
Updates the docker compose source installation to use poetry, following the switch to poetry in https://github.com/etalab/csvapi/pull/99, https://github.com/etalab/udata-hydra/pull/23, https://github.com/etalab/udata-analysis-service/pull/12.

We could iterate if we want to use the cache better to prevent reinstalling all dependencies on any source modification.